### PR TITLE
fix(evaluation): make max_questions limit corpus ingestion during dataset parsing

### DIFF
--- a/evaluation/benchmark/locomo_adapter.py
+++ b/evaluation/benchmark/locomo_adapter.py
@@ -93,6 +93,10 @@ class LoCoMoDataset(Dataset):
 
         indices = list(samples) if samples is not None else range(len(data))
         for idx in indices:
+            # 一个 sample 产出多条 query，故先按已产出数收敛到 sample 粒度，再由下方
+            # 切片截到精确条数；否则 seeds 为全量——小样本试跑会等同全量摄入。
+            if max_questions is not None and len(self._queries) >= max_questions:
+                break
             sample_id = f"sample_{idx}"
             scope = Scope(org=self._scope_org, user=sample_id)
             self._parse_sample(data[idx], sample_id, scope)

--- a/evaluation/benchmark/longmemeval_adapter.py
+++ b/evaluation/benchmark/longmemeval_adapter.py
@@ -80,6 +80,10 @@ class LongMemEvalDataset(Dataset):
 
         indices = list(samples) if samples is not None else range(len(data))
         for idx in indices:
+            # 每个 sample 恰好产出 1 条 query，故按已产出 query 数提前收敛：解析后再切
+            # 只截 queries，seeds 仍为全量——小样本试跑会等同全量摄入（数十万次写入）。
+            if max_questions is not None and len(self._queries) >= max_questions:
+                break
             self._parse_sample(data[idx])
 
         if max_questions is not None:

--- a/evaluation/scripts/run_e2e_eval.py
+++ b/evaluation/scripts/run_e2e_eval.py
@@ -33,15 +33,18 @@ qa_accuracy = import_module("evaluation.metrics.qa_metrics").qa_accuracy
 logger = logging.getLogger(__name__)
 
 
-def _load_dataset(name: str, data: str | None):
+def _load_dataset(name: str, data: str | None, max_questions: int | None = None):
+    # max_questions 同时收敛 seeds 与 queries（见适配器 _parse）：不传时整份数据集都会
+    # 被摄入，LongMemEval-S 全量约数十万次写入，试跑务必设一个小值。
+    kwargs = {"max_questions": max_questions} if max_questions is not None else {}
     if name == "locomo":
         from evaluation.benchmark.locomo_adapter import LoCoMoDataset
 
-        return LoCoMoDataset(data) if data else LoCoMoDataset()
+        return LoCoMoDataset(data, **kwargs) if data else LoCoMoDataset(**kwargs)
     if name == "longmemeval":
         from evaluation.benchmark.longmemeval_adapter import LongMemEvalDataset
 
-        return LongMemEvalDataset(data) if data else LongMemEvalDataset()
+        return LongMemEvalDataset(data, **kwargs) if data else LongMemEvalDataset(**kwargs)
     if name.endswith(".jsonl"):
         from evaluation.benchmark.jsonl_dataset import JsonlDataset
 
@@ -58,6 +61,7 @@ def main() -> int:
         help="'locomo' / 'longmemeval' 或 *.jsonl 路径",
     )
     parser.add_argument("--data", default=None, help="数据集原始文件路径（如 locomo10.json）")
+    parser.add_argument("--max-questions", type=int, default=None, help="只摄入并评测前 N 条 query（同时收敛 seeds）；试跑必设，缺省为全量")
     # judge（OpenAI 兼容；缺省读环境变量）；三者齐备才启用，否则 QA 跳过。
     parser.add_argument("--judge-model", default=os.getenv("JUDGE_MODEL"), help="judge 模型名")
     parser.add_argument(
@@ -70,7 +74,7 @@ def main() -> int:
     args = parser.parse_args()
 
     try:
-        dataset = _load_dataset(args.dataset, args.data)
+        dataset = _load_dataset(args.dataset, args.data, args.max_questions)
     except ValueError as exc:
         logger.error("%s", exc)
         return 2
@@ -80,6 +84,13 @@ def main() -> int:
         chat = openai_chat(args.judge_base_url, args.judge_model, args.judge_api_key)
         judge = LLMJudge(chat=chat, strict=args.judge_strict)
 
+    # 摄入规模先落日志：全量误跑是这条链路上最贵的一类错误。
+    logger.info(
+        "[dataset] %s | %d seeds, %d queries",
+        getattr(dataset, "name", args.dataset),
+        len(dataset.seeds()),
+        len(dataset.queries()),
+    )
     runner = Runner([ir_metrics(), perf_metrics(), qa_accuracy(judge=judge)])
     result = runner.run(dataset)
     logger.info(to_markdown(result))


### PR DESCRIPTION
Paired: [GitHub #137](https://github.com/openJiuwen-ai/agent-memory/pull/137) ↔ [GitCode !206](https://gitcode.com/openJiuwen/agent-memory/merge_requests/206)

# PR Description: fix(evaluation): make max_questions limit corpus ingestion during dataset parsing

## What type of PR is this?
`/kind bug`

## Summary
`max_questions` is documented as the way to slice a dataset before running it. However, previously it only trimmed `self._queries` after every sample had already been parsed into `self._seeds`. Consequently, a one-question pilot test still ingested the entire corpus (e.g., ~250,000 writes for LongMemEval-S).

This PR moves the limit check directly into the adapter parse loops, threads the `--max-questions` parameter through the CLI, and logs the dataset scale before ingestion begins.

## Changes Made
- **`evaluation/benchmark/longmemeval_adapter.py`**: Added early `break` guard inside the parse loop when `len(self._queries) >= max_questions`.
- **`evaluation/benchmark/locomo_adapter.py`**: Added sample-granularity early break combined with existing post-loop slicing.
- **`evaluation/scripts/run_e2e_eval.py`**: 
  - Added `--max-questions` CLI argument.
  - Threaded `max_questions` into `_load_dataset()`.
  - Added upfront scale logging (`[dataset] <name> | X seeds, Y queries`) before work starts.

## Why This Matters
- **Performance:** Single-question pilots drop from minutes of unnecessary ingestion down to ~1 second.
- **Resource Efficiency:** Prevents creating thousands of unused scopes in fulltext/vector stores.
- **Visibility:** Early logging ensures developers immediately see if they are executing a full dataset vs. a sliced pilot run.

## Verification
- **Synthetic Test Dataset (5 questions x 40 turns):**
  - Default (`max_questions=None`): 200 seeds ingested, 5 queries.
  - `max_questions=1`: 40 seeds ingested, 1 query.
  - `max_questions=3`: 120 seeds ingested, 3 queries.
- **Full Suite:** Ran `evaluation/smoke_test` (952 passed, 81 skipped). Full-size runs remain unaffected.

## Self-Checklist
- [x] **Design:** Early break correctly keeps seeds and queries aligned.
- [x] **Test:** Verified on synthetic benchmark datasets and unit test suite.
- [x] **Verification:** Confirmed dataset scale log line appears prior to ingestion.
- [x] **Interface:** Added `--max-questions` flag to `run_e2e_eval.py`.
- [x] **Document:** Updated CLI documentation and usage notes.

Related to #163 

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #163
<!-- /bot1-related-issues -->
