### PR TITLE
修复(graph_memory)：删除 _resolve_entity_merges 中重复的 episodes 扩展

### DIFF
--- a/jiuwen_memory/memory_core/graph/graph_memory/base.py
+++ b/jiuwen_memory/memory_core/graph/graph_memory/base.py
@@ -832,7 +832,7 @@ class GraphMemory:
                 map_src2tgt[src_entity.uuid] = tgt_uuid
                 src_episode_uuids = [ep if isinstance(ep, str) else ep.uuid for ep in src_entity.episodes]
                 tgt_entity.episodes.extend(src_episode_uuids)
-                tgt_entity.episodes.extend(src_episode_uuids)
+              
                 episodes_to_update.update(src_episode_uuids)
                 if not src_entity.relations:
                     continue


### PR DESCRIPTION
Fixes #216 

## 修改内容

删除 `_resolve_entity_merges` 中重复的 `tgt_entity.episodes.extend(src_episode_uuids)` 调用。

## 修改文件

- jiuwen_memory/memory_core/graph/graph_memory/base.py

## 测试

已通过本地测试验证 episodes 不再重复添加。