### PR TITLE
fix(memory): guard empty Evolver merges and rerank documents

### DIFF
--- a/jiuwen_memory/common/reranker/reranker_impl/api_reranker.py
+++ b/jiuwen_memory/common/reranker/reranker_impl/api_reranker.py
@@ -135,6 +135,10 @@ class APIReranker(Reranker):
         """
         if not texts:
             return []
+        valid_indices = [index for index, text in enumerate(texts) if text.strip()]
+        valid_texts = [texts[index] for index in valid_indices]
+        if not valid_texts:
+            return [0.0] * len(texts)
         ep = self._endpoint()
         url = (ep.base_url or self._fallback_base_url).rstrip("/") + self._spec["path"]
         build_body: Callable = self._spec["body"]
@@ -143,7 +147,7 @@ class APIReranker(Reranker):
             resp = self._client.post(
                 url,
                 headers={"Authorization": f"Bearer {ep.api_key}"},
-                json=build_body(ep.model, query, list(texts)),
+                json=build_body(ep.model, query, valid_texts),
             )
             resp.raise_for_status()
             data = resp.json()
@@ -155,8 +159,8 @@ class APIReranker(Reranker):
         scores = [0.0] * len(texts)
         for item in extract(data):
             idx = item.get("index")
-            if isinstance(idx, int) and 0 <= idx < len(scores):
-                scores[idx] = float(item.get("relevance_score", 0.0))
+            if isinstance(idx, int) and 0 <= idx < len(valid_indices):
+                scores[valid_indices[idx]] = float(item.get("relevance_score", 0.0))
         return scores
 
     def _endpoint(self):

--- a/jiuwen_memory/construction/evolver_impl/dynamic_evolver.py
+++ b/jiuwen_memory/construction/evolver_impl/dynamic_evolver.py
@@ -291,6 +291,13 @@ class DynamicEvolver(OrchestratingEvolver):
             if existing is None:
                 raise ValueError("UPDATE 决策必须提供 existing memory")
             merged = self._merge_content(existing, candidate)
+            if not merged.strip():
+                logger.warning(
+                    "DynamicEvolver: empty merge result for %s, skip update to "
+                    "preserve existing memory",
+                    existing.id[:8],
+                )
+                return 1
             if existing.segments:
                 existing.segments[0].content = merged
             else:

--- a/jiuwen_memory/construction/evolver_impl/orchestrating_evolver.py
+++ b/jiuwen_memory/construction/evolver_impl/orchestrating_evolver.py
@@ -407,6 +407,13 @@ class OrchestratingEvolver(Evolver):
         elif decision == DedupDecision.UPDATE:
             # 合成新旧 content
             merged_content = self._merge_content(existing_unit, candidate)
+            if not merged_content.strip():
+                logger.warning(
+                    "Evolver._dedup: empty merge result for %s, skip update to preserve "
+                    "existing memory",
+                    existing_unit.id[:8],
+                )
+                return 1
             # 更新 existing_unit
             if existing_unit.segments:
                 existing_unit.segments[0].content = merged_content

--- a/tests/unit/common/test_api_reranker.py
+++ b/tests/unit/common/test_api_reranker.py
@@ -92,6 +92,30 @@ def test_empty_texts_returns_empty() -> None:
     assert _reranker({"results": []}).rerank("q", []) == []
 
 
+def test_blank_texts_are_filtered_and_scores_keep_input_positions() -> None:
+    reranker, client = _reranker_with_client(
+        {
+            "results": [
+                {"index": 1, "relevance_score": 0.9},
+                {"index": 0, "relevance_score": 0.2},
+            ]
+        }
+    )
+
+    scores = reranker.rerank("q", ["", "doc1", " \t", "doc2"])
+
+    assert scores == [0.0, 0.2, 0.0, 0.9]
+    assert client.calls[0]["json"]["documents"] == ["doc1", "doc2"]
+    assert client.calls[0]["json"]["top_n"] == 2
+
+
+def test_all_blank_texts_skip_backend_request() -> None:
+    reranker, client = _reranker_with_client({"results": []})
+
+    assert reranker.rerank("q", ["", " \n"]) == [0.0, 0.0]
+    assert client.calls == []
+
+
 def test_backend_error_on_http_failure() -> None:
     reranker = _reranker({}, raise_exc=RuntimeError("502 Bad Gateway"))
     with pytest.raises(BackendError):

--- a/tests/unit/construction/test_dynamic_extraction_consolidation.py
+++ b/tests/unit/construction/test_dynamic_extraction_consolidation.py
@@ -10,7 +10,6 @@ from jiuwen_memory.common.base import PluginType
 from jiuwen_memory.common.llm.base import LLM
 from jiuwen_memory.common.security.legacy import legacy_request_context
 from jiuwen_memory.common.type_def import (
-    DedupDecision,
     MemoryTier,
     MemoryUnit,
     Modality,
@@ -22,10 +21,7 @@ from jiuwen_memory.common.type_def.memory_codec import dumps, loads
 from jiuwen_memory.config.config import Config
 from jiuwen_memory.construction.base import OperatorType
 from jiuwen_memory.construction.evolver import EvolveMode, EvolverProducer
-from jiuwen_memory.construction.evolver_impl.dynamic_evolver import (
-    ConsolidateDecision,
-    DynamicEvolver,
-)
+from jiuwen_memory.construction.evolver_impl.dynamic_evolver import DynamicEvolver
 from jiuwen_memory.construction.extractor import Extractor
 from jiuwen_memory.construction.extractor_impl.dynamic_llm_extractor import DynamicLLMExtractor
 from jiuwen_memory.construction.extractor_impl.llm_extractor import (
@@ -499,15 +495,26 @@ def test_dynamic_evolver_high_similarity_skips_llm_judge():
 def test_dynamic_evolver_empty_merge_preserves_existing_memory():
     """DynamicEvolver must not overwrite an existing unit with blank merge output."""
     existing = _unit("existing", "旧事实")
-    evolver, kv, index = _make_evolver(llm=_ScriptedLLM([" \n\t"]))
-    kv.insert(existing.scope, memory_key(existing.id), dumps(existing))
-    candidate = _unit("candidate", "新事实")
-    result = evolver._persist_decisions(
-        [candidate],
-        [ConsolidateDecision(candidate, DedupDecision.UPDATE, existing, 0.8)],
+    evolver, kv, index = _make_evolver(
+        llm=_ScriptedLLM(
+            [
+                json.dumps({"decision": "update", "existing_id": "existing"}),
+                " \n\t",
+            ]
+        ),
+        dedup_hits=[(existing, 0.8)],
+        prompts={"consolidate": {"custom": "执行巩固"}},
     )
+    kv.insert(existing.scope, memory_key(existing.id), dumps(existing))
+    candidate = _unit(
+        "candidate",
+        "新事实",
+        {"_consolidation_prompt_custom": "custom"},
+    )
+    result = evolver.evolve([candidate], EvolveMode.EXTRACT)
 
     assert result.updated_ids == []
+    assert result.created_ids == []
     assert index.updated == []
     assert existing.content == "旧事实"
     assert loads(kv.get(existing.scope, memory_key(existing.id))).content == "旧事实"

--- a/tests/unit/construction/test_dynamic_extraction_consolidation.py
+++ b/tests/unit/construction/test_dynamic_extraction_consolidation.py
@@ -10,6 +10,7 @@ from jiuwen_memory.common.base import PluginType
 from jiuwen_memory.common.llm.base import LLM
 from jiuwen_memory.common.security.legacy import legacy_request_context
 from jiuwen_memory.common.type_def import (
+    DedupDecision,
     MemoryTier,
     MemoryUnit,
     Modality,
@@ -21,7 +22,10 @@ from jiuwen_memory.common.type_def.memory_codec import dumps, loads
 from jiuwen_memory.config.config import Config
 from jiuwen_memory.construction.base import OperatorType
 from jiuwen_memory.construction.evolver import EvolveMode, EvolverProducer
-from jiuwen_memory.construction.evolver_impl.dynamic_evolver import DynamicEvolver
+from jiuwen_memory.construction.evolver_impl.dynamic_evolver import (
+    ConsolidateDecision,
+    DynamicEvolver,
+)
 from jiuwen_memory.construction.extractor import Extractor
 from jiuwen_memory.construction.extractor_impl.dynamic_llm_extractor import DynamicLLMExtractor
 from jiuwen_memory.construction.extractor_impl.llm_extractor import (
@@ -489,6 +493,24 @@ def test_dynamic_evolver_high_similarity_skips_llm_judge():
     # 高相似度 NOOP：候选不落盘
     with pytest.raises(Exception):
         kv.get(candidate.scope, memory_key(candidate.id))
+
+
+@pytest.mark.unit
+def test_dynamic_evolver_empty_merge_preserves_existing_memory():
+    """DynamicEvolver must not overwrite an existing unit with blank merge output."""
+    existing = _unit("existing", "旧事实")
+    evolver, kv, index = _make_evolver(llm=_ScriptedLLM([" \n\t"]))
+    kv.insert(existing.scope, memory_key(existing.id), dumps(existing))
+    candidate = _unit("candidate", "新事实")
+    result = evolver._persist_decisions(
+        [candidate],
+        [ConsolidateDecision(candidate, DedupDecision.UPDATE, existing, 0.8)],
+    )
+
+    assert result.updated_ids == []
+    assert index.updated == []
+    assert existing.content == "旧事实"
+    assert loads(kv.get(existing.scope, memory_key(existing.id))).content == "旧事实"
 
 
 @pytest.mark.unit

--- a/tests/unit/construction/test_evolver_dedup.py
+++ b/tests/unit/construction/test_evolver_dedup.py
@@ -631,6 +631,36 @@ class TestDedupUpdate:
         # 验证 provenance 包含候选 id
         assert "c1" in updated.provenance
 
+    @staticmethod
+    def test_empty_merge_preserves_existing_memory():
+        """空白合并结果不得静默覆写已有记忆。"""
+        stores = _create_stores()
+        llm = _MockLLM(
+            responses=[
+                json.dumps({"decision": "update", "reason": "候选补充了新信息"}),
+                " \n\t",
+            ]
+        )
+        plugins = {"embedder": _HashEmbedder(), "llm": llm}
+        evolver = _make_evolver(
+            stores["kv"],
+            stores["vector"],
+            plugins["embedder"],
+            plugins["llm"],
+            dedup_high_similarity=1.01,
+        )
+
+        existing_unit = _make_unit("e1", "用户在阿里巴巴工作")
+        _index_unit(existing_unit, stores["kv"], stores["vector"], plugins["embedder"])
+        candidate = _make_unit("c1", "用户担任高级工程师")
+
+        result = getattr(evolver, "_dedup_batch")([candidate])
+
+        assert result.updated_ids == []
+        stored = loads(stores["kv"].get(_DEFAULT_SCOPE, memory_key("e1")))
+        assert stored.content == "用户在阿里巴巴工作"
+        assert stored.provenance == []
+
 
 class TestDedupDegradation:
     """降级场景：Embedder/VectorStore/LLM 不可用时的行为。"""

--- a/tests/unit/construction/test_evolver_dedup.py
+++ b/tests/unit/construction/test_evolver_dedup.py
@@ -652,11 +652,12 @@ class TestDedupUpdate:
 
         existing_unit = _make_unit("e1", "用户在阿里巴巴工作")
         _index_unit(existing_unit, stores["kv"], stores["vector"], plugins["embedder"])
-        candidate = _make_unit("c1", "用户担任高级工程师")
+        candidate = _make_unit("c1", "用户在阿里巴巴工作")
 
         result = getattr(evolver, "_dedup_batch")([candidate])
 
         assert result.updated_ids == []
+        assert result.created_ids == []
         stored = loads(stores["kv"].get(_DEFAULT_SCOPE, memory_key("e1")))
         assert stored.content == "用户在阿里巴巴工作"
         assert stored.provenance == []


### PR DESCRIPTION
Paired: [GitHub #294](https://github.com/openJiuwen-ai/agent-memory/pull/294) ↔ [GitCode !277](https://gitcode.com/openJiuwen/agent-memory/merge_requests/277)

Closes #293

## Background

The `mem2.0` Evolver accepted an empty response from the LLM content merge step and used it to overwrite the existing memory. A subsequent recall could then pass the empty memory text to DashScope reranking, which rejects the request with HTTP 400.

## Changes

- Skip an UPDATE when either Evolver implementation receives an empty or whitespace-only merge result, preserving the existing memory and avoiding a partial update.
- Filter empty and whitespace-only documents before an API reranker request, then restore scores to the original input positions with zero scores for filtered documents.
- Add regression tests for both Evolver implementations and for mixed/all-blank reranker inputs.

## Compatibility

This keeps the existing UPDATE and reranker contracts unchanged for valid content. Blank documents are treated as non-rankable candidates and receive a `0.0` score without being sent to the provider. The PR targets `mem2.0`, which is the branch named by the reported failure; no default-branch code is changed.

## Validation

Passed:

- `python -m pytest tests/unit/construction/test_evolver_dedup.py tests/unit/construction/test_dynamic_extraction_consolidation.py tests/unit/common/test_api_reranker.py` — 44 passed.
- `ruff check` on all six changed files — passed.
- `python -m compileall -q jiuwen_memory tests` — passed.
- `git diff --check` — passed.
- `python -m build --wheel --no-isolation` — passed.

Limitations and checks not completed:

- `python -m pytest -m unit` — 1,252 passed, 11 skipped, 2 failed, 88 errors, 477 deselected. The errors were existing Windows temporary-directory permission failures; the two failures were existing entity-linker log-capture assertions in unchanged files.
- A default full `python -m pytest` run was stopped after it entered a slow external-service test path; no real LLM, reranker API, database, cache, or vector service was available or required for this unit-level fix.
- `ruff check .` reports 193 pre-existing findings outside the changed files; they were not modified to keep this PR minimal.
- `ruff format --check` reports pre-existing formatting differences in the changed files; formatting the whole files would create unrelated churn, so no formatter rewrite was applied.
- No mypy/type-check command is configured in this branch's `pyproject.toml`.

## AI disclosure

This change was prepared with AI assistance. The implementation, tests, and validation results were reviewed against the reported reproduction and the existing call paths.

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #293
<!-- /bot1-related-issues -->
