### PR TITLE
feat(retrieval): add BM25_scored_fuser coarse-ranking operator

### DIFF
--- a/jiuwen_memory/retrieval/fuser_impl/__init__.py
+++ b/jiuwen_memory/retrieval/fuser_impl/__init__.py
@@ -12,5 +12,6 @@ from jiuwen_memory.retrieval.fuser import FuserProducer
 import_module(".rrf_fuser", __name__)
 import_module(".weighted_rrf_fuser", __name__)
 import_module(".score_max_fuser", __name__)
+import_module(".bm25_scored_fuser", __name__)
 
 __all__ = ["FuserProducer"]

--- a/jiuwen_memory/retrieval/fuser_impl/bm25_scored_fuser.py
+++ b/jiuwen_memory/retrieval/fuser_impl/bm25_scored_fuser.py
@@ -1,0 +1,259 @@
+# Copyright (c) Huawei Technologies Co., Ltd. 2026. All rights reserved.
+"""BM25 粗排算子 —— 在候选并集上补一路统一的词法信号，再做 CombMAX 融合。
+
+注册名 ``BM25_scored_fusor`` 由总部指定，与配置里的 ``fuser.default.target`` 取值
+逐字对应；类名/文件名沿用本目录的 ``Fuser`` 命名。
+
+    combined(u) = max( max_c  weight_c × norm_c(u),  w_lex × norm_bm25(u) )
+
+**为什么在 Elasticsearch 装配下仍然有用。** ES 的 keyword 通道分已是带全库统计的
+Lucene ``BM25Similarity``，重估它只会更差——本算子**不重估**，只**补一路**：ES 只为
+自己那一路的 top-k 打了分，**向量通道召回的候选从未被词法打过分**。融合时候选是各路
+的并集，于是「有没有词法分」变成了「是哪一路召回的」的副产品，而不是相关性差异。
+本算子在并集上统一算一遍 BM25，把这条轴补齐；各通道原分一律保留，只增不减。
+
+与 ``score_max`` 同构（通道内 max 归一化 + 通道间取最大，F04 决策 1），词法分作为
+额外一项参与取最大。不调用 ``Reranker``（AGENTS.md 本地约束 §7），不改召回。
+
+IDF 与 avgdl 取自候选池而非全库——``Fuser`` 接口能拿到的最大范围。池宽为
+``recall_max × 在场通道数``，比精排阶段的 ``rerank_max`` 更宽。这是已知近似：
+本算子给出的是**池内相对**词法强度，不是全库可比的绝对分。
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from dataclasses import replace
+from typing import Mapping
+
+from jiuwen_memory.common.log import get_logger
+from jiuwen_memory.common.tokenizer import Tokenizer
+from jiuwen_memory.common.tokenizer.base import TokenizerProducer
+from jiuwen_memory.common.type_def import ScoredCandidate
+from jiuwen_memory.retrieval.base import RetrievalOperatorType
+from jiuwen_memory.retrieval.fuser import Fuser, FuserProducer
+from jiuwen_memory.retrieval.types import ChannelEvidence, ParsedQuery, RecallChannel
+
+from .layered_merge import merge_layered_channels
+
+logger = get_logger(__name__)
+
+
+def _bm25_scores(
+    corpus: list[list[str]], query_tokens: list[str], k1: float, b: float
+) -> list[float]:
+    """Okapi BM25（Lucene ``BM25Similarity`` 公式），返回与 ``corpus`` 同序的得分::
+
+        idf(t)   = log(1 + (N - df(t) + 0.5) / (df(t) + 0.5))
+        score(d) = Σ_t  idf(t) × freq(t,d) × (k1 + 1) / (freq(t,d) + k1 × norm(d))
+        norm(d)  = 1 - b + b × dl(d) / avgdl
+
+    与旧的词重叠表达式 ``hits / len(tokens)`` 的三点差异：IDF 加权（罕见词与停用词
+    不再等权）、词频饱和（第 10 次命中不等价于第 1 次）、长度归一强度可调（``b``）。
+    """
+    n = len(corpus)
+    if not n or not query_tokens:
+        return [0.0] * n
+    freqs = [Counter(doc) for doc in corpus]
+    df: Counter[str] = Counter()
+    for freq in freqs:
+        df.update(freq.keys())
+    total = sum(len(doc) for doc in corpus)
+    # 空批 / 全空文档：avgdl 退化为 1.0，长度归一项恒为 1，不触发除零。
+    avgdl = (total / n) if total else 1.0
+    idf = {
+        term: math.log(1.0 + (n - df.get(term, 0) + 0.5) / (df.get(term, 0) + 0.5))
+        for term in set(query_tokens)
+    }
+    scores: list[float] = []
+    for doc, freq in zip(corpus, freqs):
+        norm = k1 * (1.0 - b + b * len(doc) / avgdl)
+        score = 0.0
+        # query 内重复词按重复次数计入（与 Lucene 的 query 端行为一致）。
+        for term in query_tokens:
+            tf = freq.get(term, 0)
+            if tf:
+                score += idf[term] * tf * (k1 + 1.0) / (tf + norm)
+        scores.append(score)
+    return scores
+
+
+class BM25ScoredFuser(Fuser):
+    """候选并集上的 BM25 词法轴 + CombMAX 融合。"""
+
+    def __init__(
+        self,
+        tokenizer: Tokenizer,
+        k1: float = 1.2,
+        b: float = 0.75,
+        lexical_weight: float = 1.0,
+        channel_weights: Mapping[RecallChannel | str, float | str] | None = None,
+    ) -> None:
+        self._tokenizer = tokenizer
+        self._k1 = float(k1)
+        self._b = float(b)
+        # 词法轴相对各召回通道的话语权；0 = 关闭本算子的词法项，退化为 score_max。
+        self._lexical_weight = float(lexical_weight)
+        self._channel_weights = self._normalize_weights(channel_weights or {})
+
+    @staticmethod
+    def _normalize_weights(
+        weights: Mapping[RecallChannel | str, float | str],
+    ) -> dict[RecallChannel, float]:
+        normalized: dict[RecallChannel, float] = {}
+        for raw_channel, raw_weight in weights.items():
+            if isinstance(raw_channel, RecallChannel):
+                channel = raw_channel
+            else:
+                try:
+                    channel = RecallChannel(raw_channel)
+                except ValueError:
+                    channel = RecallChannel[raw_channel.upper()]
+            normalized[channel] = float(raw_weight)
+        return normalized
+
+    def operator_type(self) -> RetrievalOperatorType:
+        return RetrievalOperatorType.FUSER
+
+    def health(self) -> None:
+        return None
+
+    def explain(self) -> dict[str, str]:
+        ordered = sorted(self._channel_weights.items(), key=lambda item: item[0].value)
+        weights = ",".join(f"{ch.value}={w:g}" for ch, w in ordered)
+        return {
+            "strategy": "BM25_scored_fusor",
+            "normalization": "channel_max",
+            "k1": f"{self._k1:g}",
+            "b": f"{self._b:g}",
+            "lexical_weight": f"{self._lexical_weight:g}",
+            "channel_weights": weights or "default=1",
+        }
+
+    # -- 内部 ------------------------------------------------------------- #
+
+    def _query_tokens(self, query: ParsedQuery) -> list[str]:
+        # 优先用 parser 已产出的 tokens：与构建侧同一 Tokenizer 实例（铁律 §2），
+        # term 必然对得上；为空才退回自行分词。
+        if query.tokens:
+            return list(query.tokens)
+        return self._tokenizer.tokenize(query.rewritten or query.raw)
+
+    def _lexical_axis(
+        self, query: ParsedQuery, pool: dict[str, ScoredCandidate]
+    ) -> dict[str, float]:
+        """并集上的 BM25 分，已按池内最高分归一化到 [0,1]；无文本可打分时返回空。"""
+        if self._lexical_weight <= 0.0:
+            return {}
+        texts: dict[str, str] = {}
+        for uid, candidate in pool.items():
+            unit = getattr(candidate, "unit", None)
+            # 未物化的 ScoredUnit 没有内容——该候选不参与词法轴，但不因此被打成 0 分。
+            if unit is not None and unit.content:
+                texts[uid] = unit.content
+        q_tokens = self._query_tokens(query)
+        if not texts or not q_tokens:
+            logger.debug(
+                "BM25ScoredFuser lexical axis skipped: scorable=%d q_tokens=%d",
+                len(texts),
+                len(q_tokens),
+            )
+            return {}
+        order = list(texts)
+        raw = _bm25_scores(
+            [self._tokenizer.tokenize(texts[uid]) for uid in order],
+            q_tokens,
+            self._k1,
+            self._b,
+        )
+        top = max(raw) if raw else 0.0
+        if top <= 0.0:
+            return {}
+        return {uid: score / top for uid, score in zip(order, raw)}
+
+    def fuse(
+        self, query: ParsedQuery, candidates: list[list[ScoredCandidate]]
+    ) -> list[ScoredCandidate]:
+        # 分层召回下同通道占多路，先归并再归一化（与其余 Fuser 同一前处理）。
+        merged = merge_layered_channels(candidates)
+        if not merged:
+            return []
+
+        pool: dict[str, ScoredCandidate] = {}
+        for one_channel in merged:
+            for su in one_channel:
+                pool.setdefault(su.unit_id, su)
+
+        lexical = self._lexical_axis(query, pool)
+
+        best: dict[str, float] = {}
+        channel: dict[str, RecallChannel] = {}
+        evidence: dict[str, list[ChannelEvidence]] = {}
+
+        # ① 各召回通道：通道内 max 归一化后取加权分（score_max 口径，原分不动）。
+        for one_channel in merged:
+            ch = one_channel[0].channel
+            weight = self._channel_weights.get(ch, 1.0)
+            top = max(su.score for su in one_channel)
+            for rank, su in enumerate(one_channel):
+                # 非正的最高分（全零/负分通道）整路计 0，避免除零并保持
+                # 「无有效信号即不贡献」的语义。
+                normalized = (su.score / top) if top > 0 else 0.0
+                contribution = weight * normalized
+                evidence.setdefault(su.unit_id, []).append(
+                    ChannelEvidence(
+                        channel=ch,
+                        rank=rank,
+                        score=su.score,
+                        weight=weight,
+                        contribution=contribution,
+                    )
+                )
+                if contribution > best.get(su.unit_id, -1.0):
+                    best[su.unit_id] = contribution
+                    channel[su.unit_id] = ch
+
+        # ② 词法轴：并集上统一算一遍，作为额外一项参与取最大。只增不减。
+        if lexical:
+            ranked = sorted(lexical, key=lambda uid: lexical[uid], reverse=True)
+            for rank, uid in enumerate(ranked):
+                contribution = self._lexical_weight * lexical[uid]
+                evidence.setdefault(uid, []).append(
+                    ChannelEvidence(
+                        channel=RecallChannel.KEYWORD,
+                        rank=rank,
+                        score=lexical[uid],
+                        weight=self._lexical_weight,
+                        contribution=contribution,
+                    )
+                )
+                if contribution > best.get(uid, -1.0):
+                    best[uid] = contribution
+                    channel[uid] = RecallChannel.KEYWORD
+
+        fused = [
+            replace(
+                pool[uid],
+                score=score,
+                channel=channel.get(uid, RecallChannel.KEYWORD),
+                evidence=evidence.get(uid, []),
+            )
+            for uid, score in best.items()
+        ]
+        fused.sort(key=lambda su: su.score, reverse=True)
+        return fused
+
+
+# -- 注册到 FuserProducer（实现自注册，新增无需改 producer/build_kernel） -------- #
+
+
+@FuserProducer.register("BM25_scored_fusor")
+def _build(config):
+    return BM25ScoredFuser(
+        tokenizer=TokenizerProducer.dep(config, default="whitespace"),
+        k1=float(config.get("bm25_k1", 1.2)),
+        b=float(config.get("bm25_b", 0.75)),
+        lexical_weight=float(config.get("bm25_lexical_weight", 1.0)),
+        channel_weights=config.get("fusion_channel_weights", {}),
+    )

--- a/jiuwen_memory/retrieval/fuser_impl/bm25_scored_fuser.py
+++ b/jiuwen_memory/retrieval/fuser_impl/bm25_scored_fuser.py
@@ -232,15 +232,22 @@ class BM25ScoredFuser(Fuser):
                     best[uid] = contribution
                     channel[uid] = RecallChannel.KEYWORD
 
-        fused = [
-            replace(
-                pool[uid],
-                score=score,
-                channel=channel.get(uid, RecallChannel.KEYWORD),
-                evidence=evidence.get(uid, []),
+        fused: list[ScoredCandidate] = []
+        for uid, score in best.items():
+            # uid 只能来自 merged（直接建自 pool）或 lexical（其 key 建自 pool 的
+            # text），因此在 pool 中必然存在；用 .get() 取值 + 显式异常，
+            # 不做裸 dict[key]（G.TYP.07）。
+            candidate = pool.get(uid)
+            if candidate is None:
+                raise KeyError(f"BM25ScoredFuser: candidate {uid!r} scored but missing from pool")
+            fused.append(
+                replace(
+                    candidate,
+                    score=score,
+                    channel=channel.get(uid, RecallChannel.KEYWORD),
+                    evidence=evidence.get(uid, []),
+                )
             )
-            for uid, score in best.items()
-        ]
         fused.sort(key=lambda su: su.score, reverse=True)
         return fused
 

--- a/tests/unit/retrieval/test_bm25_scored_fuser.py
+++ b/tests/unit/retrieval/test_bm25_scored_fuser.py
@@ -1,0 +1,179 @@
+"""BM25 粗排算子 tests."""
+
+from __future__ import annotations
+
+import pytest
+
+from jiuwen_memory.common.factory.factory import Factory
+from jiuwen_memory.common.tokenizer.tokenizer_impl import TokenizerProducer
+from jiuwen_memory.common.type_def import MemoryUnit, ScoredMemoryUnit, Segment
+from jiuwen_memory.config.defaults import default_context
+from jiuwen_memory.retrieval.fuser_impl import FuserProducer
+from jiuwen_memory.retrieval.fuser_impl.bm25_scored_fuser import BM25ScoredFuser
+from jiuwen_memory.retrieval.fuser_impl.rrf_fuser import RRFFuser
+from jiuwen_memory.retrieval.fuser_impl.score_max_fuser import ScoreMaxFuser
+from jiuwen_memory.retrieval.types import ParsedQuery, RecallChannel, ScoredUnit
+
+pytestmark = pytest.mark.unit
+
+QUERY = ParsedQuery(raw="quarterly report", tokens=["quarterly", "report"])
+
+
+@pytest.fixture
+def tokenizer():
+    return TokenizerProducer.build("whitespace", {}, default_context())
+
+
+def _scored(unit_id: str, text: str, score: float, channel: RecallChannel):
+    return ScoredMemoryUnit(
+        MemoryUnit(id=unit_id, segments=[Segment(content=text)]), score, channel
+    )
+
+
+def test_default_config_still_uses_rrf() -> None:
+    """出厂默认不变：bm25 仅在显式配置时启用。"""
+    Factory.reset_all()
+    try:
+        assert isinstance(FuserProducer.build_named("default", default_context()), RRFFuser)
+    finally:
+        Factory.reset_all()
+
+
+def test_registered_and_params_read_from_config() -> None:
+    Factory.reset_all()
+    try:
+        fuser = FuserProducer.build(
+            "BM25_scored_fusor",
+            {"tokenizer": "default", "bm25_k1": 1.5, "bm25_b": 0.4},
+            default_context(),
+        )
+    finally:
+        Factory.reset_all()
+    assert isinstance(fuser, BM25ScoredFuser)
+    assert fuser.explain()["k1"] == "1.5"
+    assert fuser.explain()["b"] == "0.4"
+
+
+def test_lexical_axis_promotes_vector_only_candidate(tokenizer) -> None:
+    """核心用例：向量召回的候选从未被 ES 词法打过分，本算子在并集上补齐。"""
+    keyword = [_scored("u4", "quarterly revenue report annual", 5.0, RecallChannel.KEYWORD)]
+    vector = [
+        _scored("u1", "unrelated filler text here", 1.0, RecallChannel.VECTOR),
+        _scored("u3", "another unrelated passage", 0.6, RecallChannel.VECTOR),
+        _scored("u2", "quarterly report quarterly report", 0.4, RecallChannel.VECTOR),
+    ]
+
+    plain = [su.unit_id for su in ScoreMaxFuser().fuse(QUERY, [keyword, vector])]
+    with_bm25 = [su.unit_id for su in BM25ScoredFuser(tokenizer).fuse(QUERY, [keyword, vector])]
+
+    # u2 词法极强但向量分最低：未补词法轴时垫底，补齐后越过纯噪声的 u3。
+    assert plain.index("u2") > plain.index("u3")
+    assert with_bm25.index("u2") < with_bm25.index("u3")
+
+
+def test_channel_scores_are_never_lowered(tokenizer) -> None:
+    """只增不减：每个候选的融合分不低于纯 score_max 下的分。"""
+    keyword = [
+        _scored("u1", "quarterly revenue report", 3.0, RecallChannel.KEYWORD),
+        _scored("u2", "the the the report the", 1.0, RecallChannel.KEYWORD),
+    ]
+    vector = [_scored("u3", "no lexical overlap here", 0.9, RecallChannel.VECTOR)]
+
+    channels = [keyword, vector]
+    plain = {su.unit_id: su.score for su in ScoreMaxFuser().fuse(QUERY, channels)}
+    fused = {su.unit_id: su.score for su in BM25ScoredFuser(tokenizer).fuse(QUERY, channels)}
+
+    assert set(plain) == set(fused)
+    for uid, score in plain.items():
+        assert fused[uid] >= score - 1e-12
+
+
+def test_idf_and_length_norm_beat_raw_overlap(tokenizer) -> None:
+    """旧式词重叠给「重复通用词的长文档」高分；BM25 按 IDF 与长度归一压回。"""
+    vector = [
+        _scored("u1", "the the the the report the the the", 0.5, RecallChannel.VECTOR),
+        _scored("u2", "quarterly revenue report", 0.5, RecallChannel.VECTOR),
+    ]
+
+    fused = {su.unit_id: su for su in BM25ScoredFuser(tokenizer).fuse(QUERY, [vector])}
+    lexical = {
+        uid: next(e.score for e in su.evidence if e.channel is RecallChannel.KEYWORD)
+        for uid, su in fused.items()
+    }
+
+    assert lexical["u2"] > lexical["u1"]
+
+
+def test_lexical_weight_zero_degrades_to_score_max(tokenizer) -> None:
+    keyword = [_scored("u1", "quarterly revenue report", 3.0, RecallChannel.KEYWORD)]
+    vector = [_scored("u2", "no lexical overlap here", 0.9, RecallChannel.VECTOR)]
+
+    off = BM25ScoredFuser(tokenizer, lexical_weight=0.0).fuse(QUERY, [keyword, vector])
+    plain = ScoreMaxFuser().fuse(QUERY, [keyword, vector])
+
+    assert [(su.unit_id, su.score) for su in off] == [(su.unit_id, su.score) for su in plain]
+
+
+def test_evidence_records_the_lexical_axis(tokenizer) -> None:
+    keyword = [_scored("u1", "quarterly revenue report", 3.0, RecallChannel.KEYWORD)]
+
+    fused = BM25ScoredFuser(tokenizer).fuse(QUERY, [keyword])
+
+    assert len(fused[0].evidence) == 2  # 召回通道一条 + 词法轴一条
+
+
+def test_unmaterialized_candidates_skip_the_axis_without_zeroing(tokenizer) -> None:
+    """Fuser 收到未物化的 ScoredUnit 时无内容可打分，退化为通道归一化。"""
+    keyword = [
+        ScoredUnit("u1", 0.9, RecallChannel.KEYWORD),
+        ScoredUnit("u2", 0.5, RecallChannel.KEYWORD),
+    ]
+
+    fused = BM25ScoredFuser(tokenizer).fuse(QUERY, [keyword])
+
+    assert [su.unit_id for su in fused] == ["u1", "u2"]
+    assert fused[0].score == pytest.approx(1.0)
+
+
+def test_empty_query_tokens_skip_the_axis(tokenizer) -> None:
+    keyword = [_scored("u1", "quarterly revenue report", 0.5, RecallChannel.KEYWORD)]
+
+    fused = BM25ScoredFuser(tokenizer).fuse(ParsedQuery(), [keyword])
+
+    assert [su.unit_id for su in fused] == ["u1"]
+
+
+def test_no_lexical_hit_anywhere_skips_the_axis(tokenizer) -> None:
+    vector = [_scored("u1", "nothing in common", 0.5, RecallChannel.VECTOR)]
+
+    fused = BM25ScoredFuser(tokenizer).fuse(QUERY, [vector])
+
+    assert len(fused[0].evidence) == 1
+    assert fused[0].score == pytest.approx(1.0)
+
+
+def test_empty_candidates(tokenizer) -> None:
+    assert BM25ScoredFuser(tokenizer).fuse(QUERY, []) == []
+
+
+def test_layered_channels_merged_before_scoring(tokenizer) -> None:
+    """同通道分层多路先归并取 MaxP，不得被当作多个信号源。"""
+    l2 = [_scored("u1", "quarterly revenue report", 0.5, RecallChannel.KEYWORD)]
+    l0 = [_scored("u1", "quarterly revenue report", 0.9, RecallChannel.KEYWORD)]
+
+    fused = BM25ScoredFuser(tokenizer).fuse(QUERY, [l2, l0])
+
+    assert len(fused) == 1
+    assert sum(1 for e in fused[0].evidence if e.channel is RecallChannel.KEYWORD) == 2
+
+
+def test_channel_weight_suppresses_a_channel(tokenizer) -> None:
+    keyword = [_scored("u1", "quarterly revenue report", 3.0, RecallChannel.KEYWORD)]
+    vector = [_scored("u2", "no lexical overlap here", 0.9, RecallChannel.VECTOR)]
+
+    fused = BM25ScoredFuser(tokenizer, channel_weights={"vector": 0.3}).fuse(
+        QUERY, [keyword, vector]
+    )
+
+    assert fused[0].unit_id == "u1"
+    assert {su.unit_id: su.score for su in fused}["u2"] == pytest.approx(0.3)


### PR DESCRIPTION
Paired: [GitHub #322](https://github.com/openJiuwen-ai/agent-memory/pull/322) ↔ [GitCode !299](https://gitcode.com/openJiuwen/agent-memory/merge_requests/299)

Supersedes #177 . Branched fresh from `mem2.0`.

Opened as a draft: the code is complete and unit-tested, but the end-to-end
benchmark has not run yet. Results will be posted as a comment. Review of the
operator's shape, naming and registration is welcome now — that is why this is
up before the numbers.

## What this adds

A new `Fuser` implementation registered as `BM25_scored_fusor`, per HQ's
direction. Coarse ranking (粗排) is the Fuser stage in this repo's own
vocabulary — `retrieval/AGENTS.md`: *"rank 只指 Fuser，Reranker 保持独立阶段"*.

| file | change |
|---|---|
| `retrieval/fuser_impl/bm25_scored_fuser.py` | new |
| `retrieval/fuser_impl/__init__.py` | one `import_module` line |
| `tests/unit/retrieval/test_bm25_scored_fuser.py` | new |

Nothing else is modified. `config/defaults.py` is untouched, so the factory
default stays `rrf` and the operator is opt-in — same precedent F04 set for
`score_max`. `in_memory_fulltext_store.py` and `overlap_reranker.py` are not
touched.

## What it does

Elasticsearch already returns Lucene `BM25Similarity` with full collection
statistics. Rescoring that with candidate-pool statistics would be worse, so
this operator does **not** rescore it. It adds a term.

At fusion time the candidate set is the *union* of the channels. ES scored only
its own top-k for the keyword query, so **candidates recalled by the vector
channel were never scored lexically at all**. "Has a lexical score" therefore
encodes *which channel found it*, not relevance. This operator computes BM25
once over the union and folds it in as one more term in the CombMAX combination
(the `score_max` shape, F04 decision 1):

```
combined(u) = max( max_c  weight_c × norm_c(u),  w_lex × norm_bm25(u) )
```

Each channel's own score is preserved untouched. The lexical term can only raise
a candidate, never lower one — there is a test asserting exactly that against
`ScoreMaxFuser` output. `bm25_lexical_weight: 0` degrades exactly to
`score_max`.

Formula is the Lucene one:

```
idf(t)   = log(1 + (N - df(t) + 0.5) / (df(t) + 0.5))
score(d) = Σ_t  idf(t) × freq(t,d) × (k1 + 1) / (freq(t,d) + k1 × norm(d))
norm(d)  = 1 - b + b × dl(d) / avgdl
```

Matched against an independent reference implementation on 400 randomized
corpora (varying `k1`, `b`, document lengths, empty documents, empty query) at
`abs < 1e-12`.

## Why

Measured earlier on base `6b232c2`, LongMemEval, 500 questions, ES backend,
everything else held constant:

| Top10 | config |
|---|---|
| 81.00% | ES, `rerank_enabled: false` |
| 66.73% | ES + the default `overlap` scorer (`hits / (len(toks) + 1)`) |

Word-overlap scoring — no IDF, no term-frequency saturation, length
normalization applied unconditionally at full strength — is what costs those
points. On the built-in `target=memory` assembly, replacing the same expression
with BM25 moved Top10 from 64.33% to 75.55% (+56 questions). That path is out of
scope now, but it is the evidence that the scoring expression, not the backend,
was the problem.

**These numbers are not this PR's result.** They were measured at the rerank
stage, on a different base; this operator sits at the fuse stage. Its own effect
is unmeasured until the runs below complete.

## Known limits, stated up front

1. **IDF and avgdl come from the candidate pool, not the collection.** The
   `Fuser` interface has no access to global statistics. Pool width is
   `recall_max × live channels`, the widest sample available after recall, but
   the output is *pool-relative* lexical strength, not a collection-comparable
   absolute score. Normalizing to the pool maximum before combining is what
   makes it safe to compare against the other channels.
2. **CombMAX ties at the top.** Each axis's best candidate normalizes to 1.0, so
   the head of the list can tie. Pre-existing `score_max` behaviour, not
   introduced here.
3. **Unmaterialized candidates skip the lexical axis.** If a Storage pipeline
   hands the fuser `ScoredUnit` rather than `ScoredMemoryUnit`, there is no
   content to score; those candidates keep their channel scores rather than
   being zeroed.

## Config

```yaml
fuser:
  default:
    target: BM25_scored_fusor
    params:
      tokenizer: default          # shared named instance — same tokenizer as the index side
      bm25_k1: 1.2
      bm25_b: 0.75
      bm25_lexical_weight: 1.0    # 0 degrades exactly to score_max
      fusion_channel_weights: {}
```

`tokenizer: default` is load-bearing. `Factory.build_named` returns the shared
instance, so documents are tokenized with the same tokenizer that built the
index and that produced `ParsedQuery.tokens` (AGENTS.md 铁律 §2). The operator
prefers `query.tokens` and only tokenizes the raw string as a fallback.

Note the config section is spelled `fuser`, not `fusor` — that is the existing
key in `config/defaults.py`. Only the target value uses the name HQ specified.

## Tests

13 new tests, all passing. The 14 existing tests in `test_fuser.py` are
unchanged and still pass. `ruff check` and `ruff format --check` are clean on
both files.

## Open questions for the reviewer

1. **Should this become the built-in default?** I left `config/defaults.py` at
   `rrf`, so the operator is selected via assembly config. Making it the factory
   default is a one-line change, but it would also change the unit-test
   assembly, so I did not do it unprompted.
2. **`rerank_enabled` in the production profile.** `PipelineRetriever` L320
   (`survivors = [replace(survivors[i], score=scores[i]) for i in order]`)
   replaces both the order and the score this Fuser produces, and
   `globals.rerank_enabled` defaults to `True` with the `overlap` reranker. With
   that config the operator has no observable effect. I'm benchmarking both ways
   rather than blocking on this.

## Benchmark plan

`target=elasticsearch`, LongMemEval, 500 questions, same kit / judge model /
machine across every arm. **All four arms run on this PR's base commit**, not on
`6b232c2` — that base is 30 commits and 331 changed files behind current
`mem2.0`, so the older ES numbers above cannot serve as the comparison anchor.

| # | fuser | `rerank_enabled` | purpose |
|---|---|---|---|
| 1 | `rrf` | false | fresh baseline on this base — nothing to compare against without it |
| 2 | `BM25_scored_fusor` | false | the number that decides the operator |
| 3 | `score_max` | false | separates the new lexical term from the switch away from RRF |
| 4 | `BM25_scored_fusor` | true | settles open question 2 with data |

Arms 1 and 2 are the minimum. Without arm 3 a gain cannot be attributed, since
selecting this operator changes both the combination rule and adds the lexical
term. Every arm so far in this work was run once and the run-to-run noise floor
is still unmeasured; extraction is non-deterministic (15,414–15,712 API calls
across previous runs), so a repeat of one arm is planned once the four are in.

**Disclosure:** all benchmark numbers in this PR were produced with DeepSeek as
the extraction, synthesis and judge model, not GLM-5.2 — no GLM key was
available. Result paths still say `glm52` because that string is baked into the
protocol name. All comparisons are internally consistent (same model, same
judge, same machine across every arm), but absolute values are not directly
comparable to HQ's own GLM-5.2 results.

Issue: #323 

<!-- bot1-related-issues -->
Linked Closing Issues:
- Fixes #323
<!-- /bot1-related-issues -->
